### PR TITLE
Fix broken link in the examples list

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,4 +268,4 @@ Some basic examples of how to use the library could be found on the `examples`  
 - [1-to-1 nullable related](examples/1-to-1-nullable-related/README.md)
 - [1-to-1 chained related](examples/1-to-1-chained-related/README.md)
 - [1-to-N related](examples/1-to-N-related/README.md)
-- [N-to-M related](examples/N-to-M-related/README.md)
+- [N-to-M related](examples/N-to-M-related%20/README.md)


### PR DESCRIPTION
`N-to-M-related` example link seems to have an extra space at the end of its folder name, hence the link is broken.

![image](https://user-images.githubusercontent.com/43882999/204643172-e239da2b-6703-4d81-81db-49b32ebd645b.png)
