### PR TITLE
feat: use getRepository instead of createEntityManager

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -43,7 +43,7 @@ export abstract class Factory<T extends object> {
     const entity = await this.makeEntity(Object.fromEntries(preloadedAttrs) as FactorizedAttrs<T>, true)
     await this.applyEagerInstanceAttributes(entity, attrs, true)
 
-    const em = this.dataSource.createEntityManager()
+    const em = this.dataSource.getRepository<T>(this.entity)
     const savedEntity = await em.save<T>(entity, saveOptions)
 
     await this.applyLazyInstanceAttributes(savedEntity, attrs, true)


### PR DESCRIPTION
Hi,
first of all, thank you for porting the original repository to support later TypeORM versions.

My PR is a rather short one and I frankly don't know if my intended solution is too niche for the bigger picture on how general this library needs to be. But maybe I hope I can win you over. I have tapped into TypeORM only for about a week, so my judgement call might not well educated.

I am currently improving the test suite for a NodeJS project, trying to make the integration-testing developer experience as close to batteries included ecosystem like Python Django or Ruby on Rails, which was the reason why I came across your predecessor's library to support a factory_girl like pattern.

Besides adding a factory pattern to create test entities, I had also integrated [this](https://github.com/Aliheym/typeorm-transactional) library to support isolating test cases inside their own transactions which can be rolled back after execution. The problem is, that now the `typeorm-factory` entities are created in different transaction contexts, because each `Factory.create(...)` creates a new EntityManager instance.

The `typeorm-transactional` works by patching the `DataSource.manager` and `EntityManager.prototype.getRepository` (in contrast to `createEntityManager`). After some consideration where to fix my issue, I came to the conclusion that I'd rather fix this issue on the factory side, because the factories operate on a higher level of the stack and there are probably good reasons not to patch `createEntityManager` or even the underlying `EntityManagerFactory` to keep special use cases intact, where the manager creation is needed to for custom SQL queries.



 