### PR TITLE
Allow overriding entity manager creation to allow end user managing external transactions

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -43,7 +43,7 @@ export abstract class Factory<T extends object> {
     const entity = await this.makeEntity(Object.fromEntries(preloadedAttrs) as FactorizedAttrs<T>, true)
     await this.applyEagerInstanceAttributes(entity, attrs, true)
 
-    const em = this.dataSource.createEntityManager()
+    const em = this.getEntityManager()
     const savedEntity = await em.save<T>(entity, saveOptions)
 
     await this.applyLazyInstanceAttributes(savedEntity, attrs, true)
@@ -63,6 +63,10 @@ export abstract class Factory<T extends object> {
       list[index] = await this.create(overrideParams, saveOptions)
     }
     return list
+  }
+
+  protected getEntityManager() {
+    return this.dataSource.createEntityManager()
   }
 
   private async makeEntity(attrs: FactorizedAttrs<T>, shouldPersist: boolean) {


### PR DESCRIPTION
There's an existing PR for this kind of issue #156 that defines the task well but the implementation is not backward compatible. This is alternative implementation. First, copied reasoning to have this:

> Hi,
> first of all, thank you for porting the original repository to support later TypeORM versions.
> 
> My PR is a rather short one and I frankly don't know if my intended solution is too niche for the bigger picture on how general this library needs to be. But maybe I hope I can win you over. I have tapped into TypeORM only for about a week, so my judgement call might not well educated.
> 
> I am currently improving the test suite for a NodeJS project, trying to make the integration-testing developer experience as close to batteries included ecosystem like Python Django or Ruby on Rails, which was the reason why I came across your predecessor's library to support a factory_girl like pattern.
> 
> Besides adding a factory pattern to create test entities, I had also integrated [this](https://github.com/Aliheym/typeorm-transactional) library to support isolating test cases inside their own transactions which can be rolled back after execution. The problem is, that now the typeorm-factory entities are created in different transaction contexts, because each Factory.create(...) creates a new EntityManager instance.
> 
> The typeorm-transactional works by patching the DataSource.manager and EntityManager.prototype.getRepository (in contrast to createEntityManager). After some consideration where to fix my issue, I came to the conclusion that I'd rather fix this issue on the factory side, because the factories operate on a higher level of the stack and there are probably good reasons not to patch createEntityManager or even the underlying EntityManagerFactory to keep special use cases intact, where the manager creation is needed to for custom SQL queries.

The alternative implementation is entirely backward-compatible and doesn't change any actual code that executes by default. But it allows inheritance chain to override `protected getEntityManager()` to desired functionality.

Specifically to address the issue in question, we can override it like this:

```
  protected getEntityManager() {
    return this.dataSource.manager
  }
```

I hope it should be a small and compatible enough change to merge. Thanks in advance.